### PR TITLE
Removed type parameter from JourneysParameters class

### DIFF
--- a/Request/Parameters/JourneysParameters.php
+++ b/Request/Parameters/JourneysParameters.php
@@ -31,7 +31,6 @@ class JourneysParameters extends AbstractParameters
     protected $bike_distance;
     protected $car_distance;
     protected $wheelchair;
-    protected $type;
     protected $count;
     protected $min_nb_journeys;
     protected $max_nb_journeys;
@@ -203,17 +202,6 @@ class JourneysParameters extends AbstractParameters
     public function setWheelchair($wheelchair)
     {
         $this->wheelchair = $wheelchair;
-        return $this;
-    }
-
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    public function setType($type)
-    {
-        $this->type = $type;
         return $this;
     }
 

--- a/Tests/Request/Parameters/JourneysParametersTest.php
+++ b/Tests/Request/Parameters/JourneysParametersTest.php
@@ -35,7 +35,6 @@ class JourneysParametersTest extends \PHPUnit_Framework_TestCase
             'bike_distance' => 100,
             'car_distance' => 100,
             'wheelchair' => true,
-            'type' => 'comfort, rapid',
             'count' => 10
         );
         $setter->setter($testArray, $service);


### PR DESCRIPTION
The "type" parameter on journeys API is deprecated according to navitia development team.
So I removed it.