### PR TITLE
from_datetime parameter is not required

### DIFF
--- a/Request/Parameters/AbstractCoverageSchedulesParameters.php
+++ b/Request/Parameters/AbstractCoverageSchedulesParameters.php
@@ -14,7 +14,6 @@ abstract class AbstractCoverageSchedulesParameters extends AbstractCoverageParam
     /**
      * The date_time from which you want the schedules. Type: iso-date-time.
      *
-     * @Assert\NotBlank()
      * @Assert\Type(type="string")
      *
      * @var string


### PR DESCRIPTION
from_datetime parameter is not required. It's an error in navitia doc