### PR TITLE
Add disable_geojson parameters in stop and route schedules

### DIFF
--- a/Request/Parameters/CoverageRouteSchedulesParameters.php
+++ b/Request/Parameters/CoverageRouteSchedulesParameters.php
@@ -11,7 +11,11 @@ namespace Navitia\Component\Request\Parameters;
 class CoverageRouteSchedulesParameters extends AbstractCoverageSchedulesParameters
 {
     protected $max_date_times;
-    protected $disable_geojson = false;
+
+    /**
+     * @var bool
+     */
+    protected $disable_geojson;
 
     public function getMaxDateTimes()
     {

--- a/Request/Parameters/CoverageRouteSchedulesParameters.php
+++ b/Request/Parameters/CoverageRouteSchedulesParameters.php
@@ -11,6 +11,7 @@ namespace Navitia\Component\Request\Parameters;
 class CoverageRouteSchedulesParameters extends AbstractCoverageSchedulesParameters
 {
     protected $max_date_times;
+    protected $disable_geojson = false;
 
     public function getMaxDateTimes()
     {
@@ -20,5 +21,15 @@ class CoverageRouteSchedulesParameters extends AbstractCoverageSchedulesParamete
     public function setMaxDateTimes($max_date_times)
     {
         $this->max_date_times = $max_date_times;
+    }
+
+    public function getDisableGeojson()
+    {
+        return $this->disable_geojson;
+    }
+
+    public function setDisableGeojson($disableGeojson)
+    {
+        $this->disable_geojson = $disableGeojson;
     }
 }

--- a/Request/Parameters/CoverageRouteSchedulesParameters.php
+++ b/Request/Parameters/CoverageRouteSchedulesParameters.php
@@ -27,11 +27,17 @@ class CoverageRouteSchedulesParameters extends AbstractCoverageSchedulesParamete
         $this->max_date_times = $max_date_times;
     }
 
+    /**
+     * @return bool
+     */
     public function getDisableGeojson()
     {
         return $this->disable_geojson;
     }
 
+    /**
+     * @param bool $disableGeojson
+     */
     public function setDisableGeojson($disableGeojson)
     {
         $this->disable_geojson = $disableGeojson;

--- a/Request/Parameters/CoverageStopSchedulesParameters.php
+++ b/Request/Parameters/CoverageStopSchedulesParameters.php
@@ -11,6 +11,7 @@ namespace Navitia\Component\Request\Parameters;
 class CoverageStopSchedulesParameters extends AbstractCoverageSchedulesParameters
 {
     protected $max_stop_date_times;
+    protected $disable_geojson = false;
 
     public function getMaxStopDateTimes()
     {
@@ -21,5 +22,15 @@ class CoverageStopSchedulesParameters extends AbstractCoverageSchedulesParameter
     {
         $this->max_stop_date_times = $max_stop_date_times;
         return $this;
+    }
+
+    public function getDisableGeojson()
+    {
+        return $this->disable_geojson;
+    }
+
+    public function setDisableGeojson($disableGeojson)
+    {
+        $this->disable_geojson = $disableGeojson;
     }
 }

--- a/Request/Parameters/CoverageStopSchedulesParameters.php
+++ b/Request/Parameters/CoverageStopSchedulesParameters.php
@@ -11,7 +11,11 @@ namespace Navitia\Component\Request\Parameters;
 class CoverageStopSchedulesParameters extends AbstractCoverageSchedulesParameters
 {
     protected $max_stop_date_times;
-    protected $disable_geojson = false;
+
+    /**
+     * @var bool
+     */
+    protected $disable_geojson;
 
     public function getMaxStopDateTimes()
     {

--- a/Request/Parameters/CoverageStopSchedulesParameters.php
+++ b/Request/Parameters/CoverageStopSchedulesParameters.php
@@ -28,11 +28,17 @@ class CoverageStopSchedulesParameters extends AbstractCoverageSchedulesParameter
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function getDisableGeojson()
     {
         return $this->disable_geojson;
     }
 
+    /**
+     * @param bool $disableGeojson
+     */
     public function setDisableGeojson($disableGeojson)
     {
         $this->disable_geojson = $disableGeojson;


### PR DESCRIPTION
In order to be able to switch off the geojson when not needed (because really resource consuming sometimes)