### PR TITLE
add 'disable_geojson' boolean parameter in coverage queries in order

### DIFF
--- a/Request/Parameters/AbstractCoverageParameters.php
+++ b/Request/Parameters/AbstractCoverageParameters.php
@@ -34,6 +34,11 @@ abstract class AbstractCoverageParameters extends AbstractParameters
     protected $distance;
     protected $data_freshness;
 
+    /**
+     * @var bool
+     */
+    protected $disable_geojson;
+
     public function getCount()
     {
         return $this->count;
@@ -143,5 +148,21 @@ abstract class AbstractCoverageParameters extends AbstractParameters
     public function setDataFreshness($data_freshness)
     {
         $this->data_freshness = $data_freshness;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDisableGeoJson()
+    {
+        return $this->disable_geojson;
+    }
+
+    /**
+     * @param bool $disable_geojson
+     */
+    public function setDisableGeoJson($disable_geojson)
+    {
+        $this->disable_geojson = (bool)$disable_geojson;
     }
 }

--- a/Request/Parameters/CoverageRouteSchedulesParameters.php
+++ b/Request/Parameters/CoverageRouteSchedulesParameters.php
@@ -12,11 +12,6 @@ class CoverageRouteSchedulesParameters extends AbstractCoverageSchedulesParamete
 {
     protected $max_date_times;
 
-    /**
-     * @var bool
-     */
-    protected $disable_geojson;
-
     public function getMaxDateTimes()
     {
         return $this->max_date_times;
@@ -25,21 +20,5 @@ class CoverageRouteSchedulesParameters extends AbstractCoverageSchedulesParamete
     public function setMaxDateTimes($max_date_times)
     {
         $this->max_date_times = $max_date_times;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getDisableGeojson()
-    {
-        return $this->disable_geojson;
-    }
-
-    /**
-     * @param bool $disableGeojson
-     */
-    public function setDisableGeojson($disableGeojson)
-    {
-        $this->disable_geojson = $disableGeojson;
     }
 }


### PR DESCRIPTION
Hi,

We want to improve performances when we request navitia from some of our bundles.

The problem is that we can't tell navitia when geometries aren't needed in the response (It is the case for 99% of our requests). (https://github.com/CanalTP/navitia/pull/1835)
You already allowed this parameter 'disable_geojson' but only for some specific requests and it should be added for all kind.

Thank you.