### PR TITLE
Bug BO-2516 trv2 composer warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ and controls query parameters.
 
 ## Choose your version
 
-Presently this component exists in 2 major versions :
+- NavitiaComponent 1.x.x used by legacy projects in production (example NMM Realtime)
 
-- NavitiaComponent 1.x.x used by 'classic' projects in production
+- NavitiaComponent 2.x.x compatible with frameworks like Symfony4
 
-- NavitiaComponent 2.x.x compatible with modern frameworks like Symfony4
+- NavitiaComponent 3.x.x compatible with modern frameworks like Symfony5.4, with old firm name CanalTP
+
+- NavitiaComponent 4.x.x compatible with modern frameworks like Symfony5.4, with updated firm name Hove
+
+
 
 This documentation is for NavitiaComponent 2.x.x
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Navitia Component
 
-Navitia Component is a PHP library to query __Navitia 2__ Api (http://api.navitia.io),
+Navitia Component is a PHP library to query __Navitia__ Api (https://api.navitia.io),
 and controls query parameters.
 
 
@@ -10,17 +10,17 @@ and controls query parameters.
 - a Navitia token
 
 > Note:
-> If you don't have a Navitia token yet, you have to register here: http://navitia.io/register
+> If you don't have a Navitia token yet, you have to register here: https://navitia.io/register
 
 ## Choose your version
 
-- NavitiaComponent 1.x.x used by legacy projects in production (example NMM Realtime)
+- NavitiaComponent v1.x.x used by legacy projects in production (example NMM Realtime)
 
-- NavitiaComponent 2.x.x compatible with frameworks like Symfony4
+- NavitiaComponent v2.x.x compatible with frameworks like Symfony4
 
-- NavitiaComponent 3.x.x compatible with modern frameworks like Symfony5.4, with old firm name CanalTP
+- NavitiaComponent v3.x.x compatible with modern frameworks like Symfony5.4, with old firm name CanalTP
 
-- NavitiaComponent 3.1.x compatible with modern frameworks like Symfony5.4, with present firm name Hove
+- NavitiaComponent v3.1.x compatible with modern frameworks like Symfony5.4, with present firm name Hove
 
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and controls query parameters.
 
 - NavitiaComponent 3.x.x compatible with modern frameworks like Symfony5.4, with old firm name CanalTP
 
-- NavitiaComponent 4.x.x compatible with modern frameworks like Symfony5.4, with updated firm name Hove
+- NavitiaComponent 3.1.x compatible with modern frameworks like Symfony5.4, with present firm name Hove
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.1-dev"
+            "dev-master": "v3.1-dev"
         }
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "autoload": {
         "psr-4": { "Navitia\\Component\\": "" }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,4 @@
-i{
+{
     "name": "hove/navitia",
     "type": "symfony-bundle",
     "description": "Navitia Component",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.0-dev"
+            "dev-master": "3.1-dev"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,13 @@
 {
-    "name": "canaltp/navitia",
+    "name": "hove/navitia",
     "type": "library",
     "description": "Navitia Component",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Ramatoulaye Ndiaye",
-            "email": "ramatoulaye.ndiaye@canaltp.fr"
-        },
-        {
-            "name": "Johan Rouve",
-            "email": "johan.rouve@canaltp.fr"
-        }
-    ],
-    "contributors": [
-		{ "name": "Jean-Baptiste Crestot", "email": "jean-baptiste.crestot@canaltp.fr" }
-	],
     "require": {
         "php": ">=8.0.2",
         "psr/log": "2.0.*",
         "symfony/validator": "5.4.*",
-        "symfony/cache": "^6.0",
+        "symfony/cache": "^5.4",
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^2.1"
     },
@@ -29,7 +16,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "4.0-dev"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
-{
+i{
     "name": "hove/navitia",
-    "type": "library",
+    "type": "symfony-bundle",
     "description": "Navitia Component",
     "license": "MIT",
     "require": {
@@ -11,9 +11,6 @@
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^2.1"
     },
-    "autoload": {
-        "psr-4": { "Navitia\\Component\\": "" }
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.1-dev"
@@ -21,5 +18,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
+    },
+    "minimum-stability": "dev",
+    "autoload": {
+        "psr-4": { "Navitia\\Component\\": "" }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.0.2",
         "psr/log": "2.0.*",
         "symfony/validator": "5.4.*",
-        "symfony/cache": "^5.4",
+        "symfony/cache": "^6.0",
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^2.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "hove/navitia",
-    "type": "symfony-bundle",
+    "type": "library",
     "description": "Navitia Component",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
to solve https://github.com/hove-io/TrafficReport/pull/663


```
  Problem 1
  ...
    - hove/navitia ... requires symfony/cache ^5.4 -> found symfony/cache[v5.4.0, ..., v5.4.31] but the package is fixed to v6.0.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```



relates to BO-2516